### PR TITLE
Publish to GitHub Container Registry

### DIFF
--- a/.github/actions/publish-image/action.yaml
+++ b/.github/actions/publish-image/action.yaml
@@ -1,0 +1,85 @@
+name: Publish Image
+description: Publish Image
+
+inputs:
+  ref:
+    description: 'Optional - The branch, tag or SHA to checkout.'
+    required: false
+
+  registry:
+    description: The image registry to use for publishing.
+    required: true
+    default: ghcr.io
+  registry_username:
+    description: The username to use when logging into the image registry.
+    required: true
+  registry_password:
+    description: The password to use when logging into the image registry.
+    required: true
+
+  dockerfile:
+    description: The dockerfile to use for the build.
+    required: true
+  context:
+    description: The context for the build.
+    required: true
+
+  image_name:
+    description: The name of the image being published.
+    required: true
+  platforms:
+    description: 'Platforms - Comma separated list of the platforms to support.'
+    required: true
+    default: linux/amd64,linux/arm64
+
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout Code
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.ref || '' }}
+
+    - name: Cache Docker layers
+      uses: actions/cache@v4
+      with:
+        path: /tmp/.buildx-cache
+        key: ${{ runner.os }}-buildx-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-buildx-
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: |
+          ${{ inputs.registry }}/${{ inputs.image_name }}
+        tags: |
+          type=schedule
+          type=ref,event=branch
+          type=ref,event=pr
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+          type=semver,pattern={{major}}
+
+    - name: Log in to the Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ inputs.registry }}
+        username: ${{ inputs.registry_username }}
+        password: ${{ inputs.registry_password }}
+
+    - name: Build and push to the GitHub Container Registry
+      uses: docker/build-push-action@v6
+      with:
+        push: true
+        context: ${{ inputs.context }}
+        file: ${{ inputs.dockerfile }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        cache-from: type=local,src=/tmp/.buildx-cache
+        cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+        platforms: ${{ inputs.platforms }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,40 +1,68 @@
-name: bcgovimages/weasyprint - Publish
+name: Publish Backup Container Images
+run-name: Publish Backup Container ${{ inputs.tag || github.event.release.tag_name }} Images
 
-on: 
+on:
   release:
     types: [published, edited]
-  
+
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Optional - The branch, tag or SHA to checkout.'
+        required: false
+        type: string
+      platforms:
+        description: 'Platforms - Comma separated list of the platforms to support.'
+        required: true
+        default: linux/amd64
+        type: string
+
+  workflow_call:
+    inputs:
+      ref:
+        required: false
+        type: string
+      platforms:
+        required: true
+        default: linux/amd64
+        type: string
+
 jobs:
-  docker:
+  publish-image:
+    # Ensure this only runs on the main repository so we're not publishing images to other repositories.
+    if: ${{ github.event.repository.full_name == 'bcgov/weasyprint' }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        imageName: [weasyprint]
+        include:
+          - imageName: weasyprint
+            dockerFile: Dockerfile
+
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
-      - name: Login to DockerHub
-        uses: docker/login-action@v3 
+
+      - name: Lowercase repo owner
+        id: lowercase_repo_owner
+        uses: ASzc/change-string-case-action@v6
         with:
-          username: ${{ secrets.DOCKER_LOGIN }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Docker meta
-        id: meta
-        uses: crazy-max/ghaction-docker-meta@v5
+          string: ${{ github.repository_owner }}
+
+      - name: Build and publish the image
+        uses: ./.github/actions/publish-image
         with:
-          # list of Docker images to use as base name for tags
-          images: |
-            bcgovimages/weasyprint
-          # generate Docker tags based on the following events/attributes
-          tags: |
-            type=schedule
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=sha
-      - name: Push to Docker Hub
-        uses: docker/build-push-action@v6
-        with:
-          tags: ${{ steps.meta.outputs.tags }}
-          file: Dockerfile
+          ref: ${{ inputs.ref || '' }}
+          registry: ghcr.io
+          registry_username: ${{ github.actor }}
+          registry_password: ${{ secrets.GITHUB_TOKEN }}
+          dockerfile: ${{ matrix.dockerFile }}
           context: .
-          push: true
+          image_name: ${{ steps.lowercase_repo_owner.outputs.lowercase }}/${{ matrix.imageName }}
+          platforms: ${{ inputs.platforms || 'linux/amd64' }}

--- a/README.md
+++ b/README.md
@@ -20,22 +20,22 @@ The [docker-weasyprint](https://github.com/BCDevOps/docker-weasyprint) project b
 
 # Images
 
-Pre-built images can be found here; [bcgovimages/weasyprint](https://hub.docker.com/r/bcgovimages/weasyprint)
+Pre-built images can be found here; [ghcr.io/bcgov/weasyprint:63.1.0](https://github.com/bcgov/docker-weasyprint/pkgs/container/weasyprint)
 
-`docker pull bcgovimages/weasyprint`
+`docker pull ghcr.io/bcgov/weasyprint:63.1.0`
 
 # Usage - Docker Example
 
 Build the docker image
 
 ```
-docker build --no-cache -f Dockerfile -t bcgovimages/weasyprint .
+docker build --no-cache -f Dockerfile -t ghcr.io/bcgov/weasyprint .
 ```
 
 Run the docker image, exposing port 5001
 
 ```
-docker run -p 5001:5001 bcgovimages/weasyprint
+docker run -p 5001:5001 ghcr.io/bcgov/weasyprint
 ```
 
 A `POST` to `/pdf` on port 5001 with an html body will result in a response containing a PDF. The filename may be set using a query parameter, e.g.:


### PR DESCRIPTION
- Migrate to publishing images to the GitHub Container Registry
- Stop publishing to Docker Hub
- Refactor publish workflow